### PR TITLE
Fix email logo not displayed in gmail (and probably others)

### DIFF
--- a/root/src/wrapper/email.tt
+++ b/root/src/wrapper/email.tt
@@ -48,7 +48,9 @@
 		<div class="Email-header">
 			<div class="Site-logo">
 				<a href="{{ c.uri_for('/') }}">
-					<img alt="Writeoff" src="{{ c.uri_for('/static/images/logo.png') }}">
+					<img alt="Writeoff" width="134" height="49"
+						src="https://{{ c.uri_for('/static/images/logo.png') }}"
+					/>
 				</a>
 			</div>
 		</div>


### PR DESCRIPTION
Relative protocol URLs don't work for assets in emails. 

This seems to be the only asset referenced in the email templates, though a more general approach might be to force all generated urls for emails to have the HTTPS protocol attached. Unfortunately, I don't understand the framework enough to do that.