### PR TITLE
Fix "NaN%" showing up when there is only one fic

### DIFF
--- a/root/static/js/writeoff.js
+++ b/root/static/js/writeoff.js
@@ -779,7 +779,7 @@ $(document).ready(function () {
 	var resetPercentiles = function () {
 		var n = $('.Ballot .ordered .Ballot-item').length;
 		$('.Ballot .ordered .Ballot-score').each(function (i) {
-			var score = 100 * (1 - i/(n - 1));
+			var score = 100 * (1 - i/(n - 1)) || 100;
 			this.innerHTML = '<span title="' + score.toFixed(5) + '">' + Math.round(score) + '%</span>';
 		});
 	};


### PR DESCRIPTION
Simplest possible fix: When only one fix is present in the ballot, render that as "100%"